### PR TITLE
Fixed mass2_batch np.warnings not existing error, and moved mass2_gpu to its own file

### DIFF
--- a/mass_ts/__init__.py
+++ b/mass_ts/__init__.py
@@ -31,6 +31,7 @@ __email__ = 'tylerwmarrs@gmail.com'
 __version__ = '0.1.4'
 
 
-from mass_ts._mass_ts import mass, mass2, mass3, mass2_gpu
+from mass_ts._mass_ts import mass, mass2, mass3
 from mass_ts._mass2_batch import mass2_batch
+from _mass2_gpu import mass2_gpu
 from mass_ts._top_k import top_k_motifs, top_k_discords

--- a/mass_ts/__init__.py
+++ b/mass_ts/__init__.py
@@ -33,5 +33,5 @@ __version__ = '0.1.4'
 
 from mass_ts._mass_ts import mass, mass2, mass3
 from mass_ts._mass2_batch import mass2_batch
-from _mass2_gpu import mass2_gpu
+from mass_ts._mass2_gpu import mass2_gpu
 from mass_ts._top_k import top_k_motifs, top_k_discords

--- a/mass_ts/_mass2_gpu.py
+++ b/mass_ts/_mass2_gpu.py
@@ -1,0 +1,94 @@
+"""
+© 2025 Emily Maxwell Outland <emily.maxwell@colorado.edu>
+SPDX License: BSD-3-Clause
+
+_mass2_gpu.py
+
+Last Modified: 6-24-2025
+
+Created this file, so the warnings about the gpu version not being usable stay contained to this function only.
+"""
+
+# From _mass_ts
+
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+range = getattr(__builtins__, 'xrange', range)
+# end of py2 compatability boilerplate
+
+import warnings
+import numpy as np
+from mass_ts import core as mtscore
+
+try:
+    import cupy as cp
+except ModuleNotFoundError:
+    warnings.warn(
+        'GPU support will not work: cupy is not installed.')
+
+
+def mass2_gpu(ts, query):
+    """
+    Compute the distance profile for the given query over the given time
+    series. This requires cupy to be installed.
+
+    Parameters
+    ----------
+    ts : array_like
+        The array to create a rolling window on.
+    query : array_like
+        The query.
+
+    Returns
+    -------
+    An array of distances.
+
+    Raises
+    ------
+    ValueError
+        If ts is not a list or np.array.
+        If query is not a list or np.array.
+        If ts or query is not one dimensional.
+    """
+
+    # First, define this function:
+    def moving_mean_std_gpu(a, w):
+        s = cp.concatenate([cp.array([0]), cp.cumsum(a)])
+        sSq = cp.concatenate([cp.array([0]), cp.cumsum(a ** 2)])
+        segSum = s[w:] - s[:-w]
+        segSumSq = sSq[w:] - sSq[:-w]
+
+        movmean = segSum / w
+        movstd = cp.sqrt(segSumSq / w - (segSum / w) ** 2)
+
+        return (movmean, movstd)
+
+    # Then, MASS2 GPU Version Code:
+    x = cp.asarray(ts)
+    y = cp.asarray(query)
+    n = x.size
+    m = y.size
+
+    meany = cp.mean(y)
+    sigmay = cp.std(y)
+
+    meanx, sigmax = moving_mean_std_gpu(x, m)
+    meanx = cp.concatenate([cp.ones(n - meanx.size), meanx])
+    sigmax = cp.concatenate([cp.zeros(n - sigmax.size), sigmax])
+
+    y = cp.concatenate((cp.flip(y, axis=0), cp.zeros(n - m)))
+
+    X = cp.fft.fft(x)
+    Y = cp.fft.fft(y)
+    Z = X * Y
+    z = cp.fft.ifft(Z)
+
+    dist = 2 * (m - (z[m - 1:n] - m * meanx[m - 1:n] * meany) /
+                (sigmax[m - 1:n] * sigmay))
+    dist = cp.sqrt(dist)
+
+    return cp.asnumpy(dist)

--- a/mass_ts/_mass_ts.py
+++ b/mass_ts/_mass_ts.py
@@ -11,19 +11,13 @@ import warnings
 
 import numpy as np
 
-try:
-    import cupy as cp
-except ModuleNotFoundError:
-    warnings.warn(
-        'GPU support will not work. You must pip install mass-ts[gpu].')
-
 from mass_ts import core as mtscore
 
 
 def mass(ts, query, normalize_query=True, corr_coef=False):
     """
-    Compute the distance profile for the given query over the given time 
-    series. Optionally, the correlation coefficient can be returned and 
+    Compute the distance profile for the given query over the given time
+    series. Optionally, the correlation coefficient can be returned and
     the query can be normalized.
 
     Parameters
@@ -52,104 +46,44 @@ def mass(ts, query, normalize_query=True, corr_coef=False):
 
     if normalize_query:
         query = (query - np.mean(query)) / np.std(query)
-        
+
     n = len(ts)
     m = len(query)
     x = np.append(ts, np.zeros([1, n]))
     y = np.append(np.flipud(query), np.zeros([1, 2 * n - m]))
-    
+
     X = np.fft.fft(x)
     Y = np.fft.fft(y)
     Y.resize(X.shape)
     Z = X * Y
     z = np.fft.ifft(Z)
-    
+
     sumy = np.sum(y)
     sumy2 = np.sum(y ** 2)
-    
+
     cum_sumx = np.cumsum(x)
     cum_sumx2 = np.cumsum(x ** 2)
-    
+
     sumx2 = cum_sumx2[m:n] - cum_sumx2[0:n-m]
     sumx = cum_sumx[m:n] - cum_sumx[0:n-m]
     meanx = sumx / m
     sigmax2 = (sumx2 / m) - (meanx**2)
     sigmax = np.sqrt(sigmax2)
-    
+
     dist = (sumx2 - 2 * sumx * meanx + m * (meanx ** 2)) \
         / sigmax2 - 2 * (z[m:n] - sumy * meanx) \
         / sigmax + sumy2
     dist = np.absolute(np.sqrt(dist))
-    
+
     if corr_coef:
         return 1 - np.absolute(dist) / (2 * m)
-    
+
     return dist
-
-
-def mass2_gpu(ts, query):
-    """
-    Compute the distance profile for the given query over the given time 
-    series. This require cupy to be installed.
-
-    Parameters
-    ----------
-    ts : array_like
-        The array to create a rolling window on.
-    query : array_like
-        The query.
-
-    Returns
-    -------
-    An array of distances.
-
-    Raises
-    ------
-    ValueError
-        If ts is not a list or np.array.
-        If query is not a list or np.array.
-        If ts or query is not one dimensional.
-    """
-    def moving_mean_std_gpu(a, w):
-        s = cp.concatenate([cp.array([0]), cp.cumsum(a)])
-        sSq = cp.concatenate([cp.array([0]), cp.cumsum(a ** 2)])
-        segSum = s[w:] - s[:-w]
-        segSumSq = sSq[w:] -sSq[:-w]
-    
-        movmean = segSum / w
-        movstd = cp.sqrt(segSumSq / w - (segSum / w) ** 2)
-    
-        return (movmean, movstd)
-
-    x = cp.asarray(ts)
-    y = cp.asarray(query)
-    n = x.size
-    m = y.size
-
-    meany = cp.mean(y)
-    sigmay = cp.std(y)
-    
-    meanx, sigmax = moving_mean_std_gpu(x, m)
-    meanx = cp.concatenate([cp.ones(n - meanx.size), meanx])
-    sigmax = cp.concatenate([cp.zeros(n - sigmax.size), sigmax])
-    
-    y = cp.concatenate((cp.flip(y, axis=0), cp.zeros(n - m)))
-    
-    X = cp.fft.fft(x)
-    Y = cp.fft.fft(y)
-    Z = X * Y
-    z = cp.fft.ifft(Z)
-    
-    dist = 2 * (m - (z[m - 1:n] - m * meanx[m - 1:n] * meany) / 
-                    (sigmax[m - 1:n] * sigmay))
-    dist = cp.sqrt(dist)
-
-    return cp.asnumpy(dist)
 
 
 def mass2(ts, query):
     """
-    Compute the distance profile for the given query over the given time 
+    Compute the distance profile for the given query over the given time
     series. Optionally, the correlation coefficient can be returned.
 
     Parameters
@@ -179,30 +113,30 @@ def mass2(ts, query):
 
     meany = np.mean(y)
     sigmay = np.std(y)
-    
+
     meanx = mtscore.moving_average(x, m)
     meanx = np.append(np.ones([1, len(x) - len(meanx)]), meanx)
     sigmax = mtscore.moving_std(x, m)
     sigmax = np.append(np.zeros([1, len(x) - len(sigmax)]), sigmax)
-    
+
     y = np.append(np.flip(y), np.zeros([1, n - m]))
-    
+
     X = np.fft.fft(x)
     Y = np.fft.fft(y)
     Y.resize(X.shape)
     Z = X * Y
     z = np.fft.ifft(Z)
-    
-    dist = 2 * (m - (z[m - 1:n] - m * meanx[m - 1:n] * meany) / 
+
+    dist = 2 * (m - (z[m - 1:n] - m * meanx[m - 1:n] * meany) /
                     (sigmax[m - 1:n] * sigmay))
     dist = np.sqrt(dist)
-    
+
     return dist
 
 
 def mass3(ts, query, pieces):
     """
-    Compute the distance profile for the given query over the given time 
+    Compute the distance profile for the given query over the given time
     series. This version of MASS is hardware efficient given the right number
     of pieces.
 
@@ -230,43 +164,43 @@ def mass3(ts, query, pieces):
     ts, query = mtscore.precheck_series_and_query(ts, query)
 
     m = len(query)
-    
+
     if pieces < m:
         raise ValueError('pieces should be larger than the query length.')
-    
+
     n = len(ts)
     k = pieces
     x = ts
     dist = np.array([])
-    
+
     # compute stats in O(n)
     meany = np.mean(query)
     sigmay = np.std(query)
-    
+
     meanx = mtscore.moving_average(x, m)
     meanx = np.append(np.ones([1, len(x) - len(meanx)]), meanx)
     sigmax = mtscore.moving_std(x, m)
     sigmax = np.append(np.zeros([1, len(x) - len(sigmax)]), sigmax)
-    
+
     # reverse the query and append zeros
     y = np.append(np.flip(query), np.zeros(pieces - m))
-    
+
     step_size = k - m + 1
     stop = n - k + 1
-       
+
     for j in range(0, stop, step_size):
         # The main trick of getting dot products in O(n log n) time
         X = np.fft.fft(x[j:j + k])
         Y = np.fft.fft(y)
-        
+
         Z = X * Y
         z = np.fft.ifft(Z)
-            
+
         d = 2 * (m-(z[m - 1:k] - m * meanx[m + j - 1:j + k] * meany) /
                    (sigmax[m + j - 1:j + k] * sigmay))
         d = np.sqrt(d)
         dist = np.append(dist, d)
-   
+
     j = j + k - m
     k = n - j - 1
     if k >= m:
@@ -279,8 +213,8 @@ def mass3(ts, query, pieces):
 
         d = 2 * (m-(z[m - 1:k] - m * meanx[j + m - 1:n - 1] * meany) /
                  (sigmax[j + m - 1:n - 1] * sigmay))
-       
+
         d = np.sqrt(d)
         dist = np.append(dist, d)
-    
+
     return np.array(dist)


### PR DESCRIPTION
In trying to use mass2_batch, it didn't work because np.warnings is not real (or is deprecated). I'm assuming the real warnings package was intended, so I changed it to that. I also changed n_jobs < 1 to default to n_jobs = 1 because using all available cpus when that possibly wasn't intended seems like a great way to promise failure. n_jobs = 1 will just be slow.

Additionally, I don't want the gpu version, and I'm tired of hearing about (or supressing the warning about) how I can't run it without cupy every time I import mass_ts. Thus, I moved it to its very own file, so everything is still there (including the warning) without bothering me when I'm trying to run something else.